### PR TITLE
Fixes for build errors, add support for more types of component definitions

### DIFF
--- a/examples/anonfunc3/src/App.js
+++ b/examples/anonfunc3/src/App.js
@@ -1,0 +1,35 @@
+import React from 'react';
+
+import {
+  Route,
+  NavLink,
+  Switch,
+} from 'react-router-dom';
+
+import List from './components/List';
+import Detail from './components/Detail';
+
+function App() {
+  return (
+    <div id="react-main-app">
+      <div className="container">
+        <h1><img src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9Ii0xMS41IC0xMC4yMzE3NCAyMyAyMC40NjM0OCI+CiAgPHRpdGxlPlJlYWN0IExvZ288L3RpdGxlPgogIDxjaXJjbGUgY3g9IjAiIGN5PSIwIiByPSIyLjA1IiBmaWxsPSIjNjFkYWZiIi8+CiAgPGcgc3Ryb2tlPSIjNjFkYWZiIiBzdHJva2Utd2lkdGg9IjEiIGZpbGw9Im5vbmUiPgogICAgPGVsbGlwc2Ugcng9IjExIiByeT0iNC4yIi8+CiAgICA8ZWxsaXBzZSByeD0iMTEiIHJ5PSI0LjIiIHRyYW5zZm9ybT0icm90YXRlKDYwKSIvPgogICAgPGVsbGlwc2Ugcng9IjExIiByeT0iNC4yIiB0cmFuc2Zvcm09InJvdGF0ZSgxMjApIi8+CiAgPC9nPgo8L3N2Zz4K" width="50" height="50" alt="React logo"/> React App</h1>
+        <hr/>
+        <p>
+            This is the React section page.
+            This section is displayed when url starts with "/react" prefix.
+        </p>
+        <nav id="links">
+          <NavLink to="/" activeClassName="active" exact="true">List</NavLink>
+          <NavLink to="/detail" activeClassName="active" exact="true">Detail</NavLink>
+        </nav>
+        <Switch>
+          <Route exact path="/" component={List} />
+          <Route path="/detail" component={Detail} />
+        </Switch>
+      </div>
+    </div>
+  );
+}
+
+export default App;

--- a/examples/anonfunc3/src/components/Detail.js
+++ b/examples/anonfunc3/src/components/Detail.js
@@ -1,0 +1,12 @@
+// Example taken from https://github.com/jualoppaz/single-spa-react-app
+
+import React from 'react';
+
+const Detail = () => (
+  <div>
+    <h2>Detail page</h2>
+    <p>If you are seeing this is due to you navigated from List page.</p>
+  </div>
+);
+
+export default Detail;

--- a/examples/anonfunc3/src/components/List.js
+++ b/examples/anonfunc3/src/components/List.js
@@ -1,0 +1,14 @@
+// Example taken from https://github.com/jualoppaz/single-spa-react-app
+
+import React from 'react';
+
+const List = () => (
+  <div>
+    <h2>List page</h2>
+    <p>
+      This is the initial page. You'll see this page when navigate to React section from navbar.
+    </p>
+  </div>
+);
+
+export default List;

--- a/examples/anonfunc3/src/index.js
+++ b/examples/anonfunc3/src/index.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import { BrowserRouter } from 'react-router-dom';
+
+import App from './App';
+
+export default class Root extends React.Component {
+  render() {
+    return (
+      <BrowserRouter basename="/react">
+        <App />
+      </BrowserRouter>
+    );
+  }
+}

--- a/examples/jsxelement/src/AdminTextSetting.js
+++ b/examples/jsxelement/src/AdminTextSetting.js
@@ -1,0 +1,18 @@
+import React from 'react';
+
+const AdminTextSetting = (props) => {
+    const {setByEnv, disabled, ...sharedProps} = props;
+    const isTextDisabled = disabled || setByEnv;
+
+    return (
+        <TextSetting
+            {...sharedProps}
+            labelClassName='col-sm-4'
+            inputClassName='col-sm-8'
+            disabled={isTextDisabled}
+            footer={setByEnv ? <SetByEnv/> : null}
+        />
+    );
+};
+
+export default AdminTextSetting;

--- a/examples/jsxelement/src/App.js
+++ b/examples/jsxelement/src/App.js
@@ -1,13 +1,15 @@
 import React from "react"
 import { HashRouter } from "react-router-dom"
 
-import { Badge } from "./Badge"
+import TextSetting from "./TextSetting"
+import AdminTextSetting from "./AdminTextSetting"
 
 export default function App() {
   return (
     <HashRouter>
       <React.Fragment>
-        <Badge></Badge>
+        <TextSetting></TextSetting>
+        <AdminTextSetting></AdminTextSetting>
       </React.Fragment>
     </HashRouter>
   )

--- a/examples/jsxelement/src/TextSetting.js
+++ b/examples/jsxelement/src/TextSetting.js
@@ -1,0 +1,83 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+
+export default class TextSetting extends React.PureComponent {
+    static validTypes = ['input', 'textarea', 'number', 'email', 'tel', 'url', 'password'];
+
+    static defaultProps = {
+        labelClassName: '',
+        inputClassName: '',
+        type: 'input',
+        maxLength: -1, // A negative number allows for values of any length
+        resizable: true,
+    };
+
+    handleChange = (e) => {
+        if (this.props.type === 'number') {
+            this.props.onChange(this.props.id, parseInt(e.target.value, 10));
+        } else {
+            this.props.onChange(this.props.id, e.target.value);
+        }
+    }
+
+    render() {
+        const {resizable} = this.props;
+        let {type} = this.props;
+        let input = null;
+
+        if (type === 'textarea') {
+            let style = {};
+            if (!resizable) {
+                style = Object.assign({}, {resize: 'none'});
+            }
+
+            input = (
+                <textarea
+                    autoFocus={this.props.autoFocus}
+                    data-testid={this.props.id + 'input'}
+                    id={this.props.id}
+                    style={style}
+                    className='form-control'
+                    rows={5}
+                    placeholder={this.props.placeholder}
+                    value={this.props.value}
+                    maxLength={this.props.maxLength}
+                    onChange={this.handleChange}
+                    disabled={this.props.disabled}
+                />
+            );
+        } else {
+            type = ['input', 'email', 'tel', 'number', 'url', 'password'].includes(type) ? type : 'input';
+
+            input = (
+                <input
+                    autoFocus={this.props.autoFocus}
+                    data-testid={this.props.id + type}
+                    id={this.props.id}
+                    className='form-control'
+                    type={type}
+                    placeholder={this.props.placeholder}
+                    value={this.props.value}
+                    maxLength={this.props.maxLength}
+                    onChange={this.handleChange}
+                    disabled={this.props.disabled}
+                />
+            );
+        }
+
+        return (
+            <div
+                label={this.props.label}
+                labelClassName={this.props.labelClassName}
+                inputClassName={this.props.inputClassName}
+                helpText={this.props.helpText}
+                inputId={this.props.id}
+                footer={this.props.footer}
+            >
+                {input}
+            </div>
+        );
+    }
+}

--- a/examples/jsxelement/src/index.js
+++ b/examples/jsxelement/src/index.js
@@ -1,0 +1,11 @@
+import "core-js/es6/map";
+import "core-js/es6/set";
+import "raf/polyfill";
+
+import React from "react";
+import ReactDOM from "react-dom";
+
+import App from "./App";
+
+const root = document.getElementById("root");
+ReactDOM.render(<App />, root);

--- a/examples/parsetests/src/App.js
+++ b/examples/parsetests/src/App.js
@@ -1,0 +1,25 @@
+import uuid from './uuid'
+
+uuid()
+
+const LazyRoot = React.lazy(() => import('./exporting'));
+
+useExports()
+
+function useExports(a1, a2, a3, a4, a5) {
+  LazyRoot
+}
+
+import React from "react"
+import { HashRouter } from "react-router-dom"
+import ShortcutsModal from "./shortcuts-modal"
+
+export default function App() {
+  return (
+    <HashRouter>
+      <React.Fragment>
+        <ShortcutsModal></ShortcutsModal>
+      </React.Fragment>
+    </HashRouter>
+  )
+}

--- a/examples/parsetests/src/exporting.js
+++ b/examples/parsetests/src/exporting.js
@@ -1,0 +1,15 @@
+
+export const dashboardStatesByName = addDashboardParentToStates(addNamesToStates(dashboardStateConfigs));
+const topLevelStates = addNamesToStates(topLevelStateConfigs);
+
+export const webappStates = (Object.values(dashboardStatesByName))
+  .concat(Object.values(topLevelStates));
+
+export const topLevelRoutingRules = routingRules;
+
+export const defaultState = dashboardStatesByName.index;
+export const syndicationDefaultState = dashboardStatesByName['syndication.summary'];
+export const loggedOutDefaultState = topLevelStates.login;
+
+function addDashboardParentToStates(arg1) { arg1 }
+function addNamesToStates(arg1) { arg1 }

--- a/examples/parsetests/src/index.js
+++ b/examples/parsetests/src/index.js
@@ -1,0 +1,11 @@
+import "core-js/es6/map";
+import "core-js/es6/set";
+import "raf/polyfill";
+
+import React from "react";
+import ReactDOM from "react-dom";
+
+import App from "./App";
+
+const root = document.getElementById("root");
+ReactDOM.render(<App />, root);

--- a/examples/parsetests/src/shortcuts-modal.js
+++ b/examples/parsetests/src/shortcuts-modal.js
@@ -1,0 +1,175 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// Example taken from https://github.com/mattermost/mattermost-webapp
+
+import React from 'react';
+import {Modal} from 'react-bootstrap';
+
+class ShortcutsModal extends React.PureComponent {
+    static propTypes = {
+        intl: intlShape.isRequired,
+        isMac: PropTypes.bool.isRequired,
+    }
+
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            show: false,
+        };
+    }
+
+    handleToggle = () => {
+        //toggles the state of shortcut dialog
+        this.setState({
+            show: !this.state.show,
+        });
+    }
+
+    handleHide = () => {
+        this.setState({show: false});
+    }
+
+    getShortcuts() {
+        const {isMac} = this.props;
+        const shortcuts = {};
+        Object.keys(allShortcuts).forEach((s) => {
+            if (isMac && allShortcuts[s].mac) {
+                shortcuts[s] = allShortcuts[s].mac;
+            } else if (!isMac && allShortcuts[s].default) {
+                shortcuts[s] = allShortcuts[s].default;
+            } else {
+                shortcuts[s] = allShortcuts[s];
+            }
+        });
+
+        return shortcuts;
+    }
+
+    render() {
+        const shortcuts = this.getShortcuts();
+        const {formatMessage} = this.props.intl;
+
+        const isLinux = true
+
+        return (
+            <Modal
+                dialogClassName='a11y__modal shortcuts-modal'
+                show={this.state.show}
+                onHide={this.handleHide}
+                onExited={this.handleHide}
+                role='dialog'
+                aria-labelledby='shortcutsModalLabel'
+            >
+                <div className='shortcuts-content'>
+                    <Modal.Header closeButton={true}>
+                        <Modal.Title
+                            componentClass='h1'
+                            id='shortcutsModalLabel'
+                        >
+                            <strong>{renderShortcut(formatMessage(shortcuts.mainHeader))}</strong>
+                        </Modal.Title>
+                    </Modal.Header>
+                    <Modal.Body>
+                        <div className='row'>
+                            <div className='col-sm-4'>
+                                <div className='section'>
+                                    <div>
+                                        <h4 className='section-title'><strong>{formatMessage(shortcuts.navHeader)}</strong></h4>
+                                        {renderShortcut(formatMessage(shortcuts.navPrev))}
+                                        {renderShortcut(formatMessage(shortcuts.navNext))}
+                                        {renderShortcut(formatMessage(shortcuts.navUnreadPrev))}
+                                        {renderShortcut(formatMessage(shortcuts.navUnreadNext))}
+                                        {!isLinux && renderShortcut(formatMessage(shortcuts.teamNavPrev))}
+                                        {!isLinux && renderShortcut(formatMessage(shortcuts.teamNavNext))}
+                                        {renderShortcut(formatMessage(shortcuts.teamNavSwitcher))}
+                                        {renderShortcut(formatMessage(shortcuts.navSwitcher))}
+                                        {renderShortcut(formatMessage(shortcuts.navDMMenu))}
+                                        {renderShortcut(formatMessage(shortcuts.navSettings))}
+                                        {renderShortcut(formatMessage(shortcuts.navMentions))}
+                                        {renderShortcut(formatMessage(shortcuts.navFocusCenter))}
+                                        {renderShortcut(formatMessage(shortcuts.navOpenCloseSidebar))}
+                                    </div>
+                                </div>
+                            </div>
+                            <div className='col-sm-4'>
+                                <div className='section'>
+                                    <div>
+                                        <h4 className='section-title'><strong>{formatMessage(shortcuts.msgHeader)}</strong></h4>
+                                        <span><strong>{formatMessage(shortcuts.msgInputHeader)}</strong></span>
+                                        <div className='subsection'>
+                                            {renderShortcut(formatMessage(shortcuts.msgEdit))}
+                                            {renderShortcut(formatMessage(shortcuts.msgReply))}
+                                            {renderShortcut(formatMessage(shortcuts.msgLastReaction))}
+                                            {renderShortcut(formatMessage(shortcuts.msgReprintPrev))}
+                                            {renderShortcut(formatMessage(shortcuts.msgReprintNext))}
+                                        </div>
+                                        <span><strong>{formatMessage(shortcuts.msgCompHeader)}</strong></span>
+                                        <div className='subsection'>
+                                            {renderShortcut(formatMessage(shortcuts.msgCompUsername))}
+                                            {renderShortcut(formatMessage(shortcuts.msgCompChannel))}
+                                            {renderShortcut(formatMessage(shortcuts.msgCompEmoji))}
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div className='col-sm-4'>
+                                <div className='section'>
+                                    <div>
+                                        <h4 className='section-title'><strong>{formatMessage(shortcuts.filesHeader)}</strong></h4>
+                                        {renderShortcut(formatMessage(shortcuts.filesUpload))}
+                                    </div>
+                                    <div className='section--lower'>
+                                        <h4 className='section-title'><strong>{formatMessage(shortcuts.browserHeader)}</strong></h4>
+                                        {renderShortcut(formatMessage(shortcuts.browserChannelPrev))}
+                                        {renderShortcut(formatMessage(shortcuts.browserChannelNext))}
+                                        {renderShortcut(formatMessage(shortcuts.browserFontIncrease))}
+                                        {renderShortcut(formatMessage(shortcuts.browserFontDecrease))}
+                                        <span><strong>{formatMessage(shortcuts.browserInputHeader)}</strong></span>
+                                        <div className='subsection'>
+                                            {renderShortcut(formatMessage(shortcuts.browserHighlightPrev))}
+                                            {renderShortcut(formatMessage(shortcuts.browserHighlightNext))}
+                                            {renderShortcut(formatMessage(shortcuts.browserNewline))}
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div className='info__label'>{formatMessage(shortcuts.info)}</div>
+                    </Modal.Body>
+                </div>
+            </Modal>
+        );
+    }
+}
+
+function renderShortcut(text) {
+    if (!text) {
+        return null;
+    }
+
+    const shortcut = text.split('\t');
+    const description = <span>{shortcut[0]}</span>;
+
+    let keys = null;
+    if (shortcut.length > 1) {
+        keys = shortcut[1].split('|').map((key) => (
+            <span
+                className='shortcut-key'
+                key={key}
+            >
+                {key}
+            </span>
+        ));
+    }
+
+    return (
+        <div className='shortcut-line'>
+            {description}
+            {keys}
+        </div>
+    );
+}
+
+export default ShortcutsModal;

--- a/examples/parsetests/src/uuid.js
+++ b/examples/parsetests/src/uuid.js
@@ -1,0 +1,10 @@
+function rand4HexStr() {
+  return Math.floor((1 + Math.random()) * 0x10000)
+    .toString(16)
+    .substring(1);
+}
+
+export default function() {
+  return `${rand4HexStr() + rand4HexStr()}-${rand4HexStr()}-${rand4HexStr()}-${
+    rand4HexStr()}-${rand4HexStr()}${rand4HexStr()}${rand4HexStr()}`;
+}

--- a/lib/module-appender.js
+++ b/lib/module-appender.js
@@ -1,10 +1,10 @@
 const NullDependency = require("webpack/lib/dependencies/NullDependency")
 
 class ModuleAppenderDependency extends NullDependency {
-  constructor(expression, useLength) {
+  constructor(expression, range) {
     super()
     this.expression = expression
-    this.useLength = useLength
+    this.range = range
   }
 
   updateHash(hash) {
@@ -15,8 +15,7 @@ class ModuleAppenderDependency extends NullDependency {
 
 ModuleAppenderDependency.Template = class ModuleAppenderDependencyTemplate {
   apply(dep, source) {
-    const length = dep.useLength ? source._source._value.length + 1 : undefined
-    source.insert(length, dep.expression)
+    source.insert(dep.range[1], dep.expression)
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-react-component-name",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Makes React component names public on minified bundles",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "prop-types": "^15.7.2",
     "raf": "^3.4.1",
     "react": "^16.13.1",
+    "react-bootstrap": "^1.3.0",
     "react-dom": "^16.8.1",
     "react-hook-utils": "^1.0.6",
     "react-router-dom": "^4.4.0-beta.6",

--- a/test/constants.js
+++ b/test/constants.js
@@ -13,7 +13,15 @@ const MODULE_CONFIG = {
         options: {
           presets: ["@babel/preset-env", "@babel/preset-react"],
           plugins: [
-            ["@babel/plugin-transform-react-jsx"],
+            [
+              "@babel/plugin-transform-react-jsx",
+            ],
+            [
+              "@babel/plugin-proposal-class-properties",
+              {
+                "loose": true
+              }
+            ]
           ]
         },
       }
@@ -21,6 +29,21 @@ const MODULE_CONFIG = {
     {
       test: /\.css$/i,
       use: ['style-loader', 'css-loader'],
+    }
+  ]
+}
+
+const MODULE2_CONFIG = {
+  rules: [
+    {
+      test: /\.js?$/,
+      exclude: [path.resolve(__dirname, 'node_modules')],
+      use: {
+        loader: 'babel-loader',
+        options: {
+          presets: ["@babel/preset-react"],
+        },
+      }
     }
   ]
 }
@@ -44,6 +67,17 @@ exports.ANON_FUNC2_WEBPACK_CONFIG = {
   },
   module: MODULE_CONFIG
 }
+
+exports.ANON_FUNC3_WEBPACK_CONFIG = {
+  mode: PRODUCTION_MODE,
+  entry: path.join(__dirname, '../examples/anonfunc3/src/index.js'),
+  output: {
+    path: OUTPUT_DIR,
+    filename: 'anonfunc3bundle.js'
+  },
+  module: MODULE2_CONFIG
+}
+
 
 exports.CLASS_COMPONENT_WEBPACK_CONFIG = {
   mode: PRODUCTION_MODE,
@@ -71,6 +105,26 @@ exports.FORWARD_REF_WEBPACK_CONFIG = {
   output: {
     path: OUTPUT_DIR,
     filename: 'forwardrefbundle.js'
+  },
+  module: MODULE_CONFIG
+}
+
+exports.JSXELEMENT_WEBPACK_CONFIG = {
+  mode: PRODUCTION_MODE,
+  entry: path.join(__dirname, '../examples/jsxelement/src/index.js'),
+  output: {
+    path: OUTPUT_DIR,
+    filename: 'jsxelementbundle.js'
+  },
+  module: MODULE_CONFIG
+}
+
+exports.PARSE_TESTS_WEBPACK_CONFIG = {
+  mode: PRODUCTION_MODE,
+  entry: path.join(__dirname, '../examples/parsetests/src/index.js'),
+  output: {
+    path: OUTPUT_DIR,
+    filename: 'parsetestsbundle.js'
   },
   module: MODULE_CONFIG
 }

--- a/test/plugin.spec.js
+++ b/test/plugin.spec.js
@@ -57,6 +57,22 @@ describe('WebpackReactComponentNamePlugin', () => {
     expect(numDisplayNameProperties).toEqual(4)
   })
 
+  it('generates displayName for components defined via anonymous function (variation 3)', async () => {
+    const result = await utils.testWebpackPlugin(_.merge(constants.ANON_FUNC3_WEBPACK_CONFIG, {
+      plugins: [new WebpackReactComponentNamePlugin()],
+    }))
+
+    const minifiedSource = result.compilation.assets[constants.ANON_FUNC3_WEBPACK_CONFIG.output.filename]._value
+
+    const numDisplayNameProperties = (minifiedSource.match(DISPLAY_NAME_REGEX) || []).length
+
+    expect(minifiedSource).toContain('.displayName="App"')
+    expect(minifiedSource).toContain('.displayName="Root"')
+    expect(minifiedSource).toContain('.displayName="List"')
+    expect(minifiedSource).toContain('.displayName="Detail"')
+    expect(numDisplayNameProperties).toEqual(6)
+  })
+
   it('generates displayName for components defined via class', async () => {
     const result = await utils.testWebpackPlugin  (_.merge(constants.CLASS_COMPONENT_WEBPACK_CONFIG, {
       plugins: [new WebpackReactComponentNamePlugin()],
@@ -111,5 +127,33 @@ describe('WebpackReactComponentNamePlugin', () => {
     expect(minifiedSource).toContain('.displayName="App"')
     expect(minifiedSource).toContain('.displayName="UIButton"')
     expect(numDisplayNameProperties).toEqual(4)
+  })
+
+  it('generates displayName for components extending JSXElement', async () => {
+    const result = await utils.testWebpackPlugin(_.merge(constants.JSXELEMENT_WEBPACK_CONFIG, {
+      plugins: [new WebpackReactComponentNamePlugin()],
+    }))
+
+    const minifiedSource = result.compilation.assets[constants.JSXELEMENT_WEBPACK_CONFIG.output.filename]._value
+
+    const numDisplayNameProperties = (minifiedSource.match(DISPLAY_NAME_REGEX) || []).length
+
+    expect(minifiedSource).toContain('.displayName="App"')
+    expect(minifiedSource).toContain('.displayName="AdminTextSetting"')
+    expect(minifiedSource).toContain('.displayName="TextSetting"')
+    expect(numDisplayNameProperties).toEqual(5)
+  })
+
+  it('parses and ignores files that do not include React component definitions', async () => {
+    const result = await utils.testWebpackPlugin(_.merge(constants.PARSE_TESTS_WEBPACK_CONFIG, {
+      plugins: [new WebpackReactComponentNamePlugin()],
+    }))
+
+    const minifiedSource = result.compilation.assets[constants.PARSE_TESTS_WEBPACK_CONFIG.output.filename]._value
+
+    const numDisplayNameProperties = (minifiedSource.match(DISPLAY_NAME_REGEX) || []).length
+
+    expect(minifiedSource).toContain('.displayName="App"')
+    expect(numDisplayNameProperties).toEqual(11)
   })
 })


### PR DESCRIPTION
- Adds null checks in the logic that traverses the AST.  Prevents users from getting 'unable to access property 'type' of undefined' errors.
- displayName property definitions are now emitted directly after the variable / function / class definition, rather than at the end of the file. Fixes build errors that a few people hit.
- Now detects when component is defined as extending JSXElement and when it is defined as a class extending Component/PureComponent
- Only parse files that end in .js/.jsx/.ts/.tsx
- Ignore function names / variable names that are lowercase. This is a simple heuristic to avoid adding displayName to helper functions.

**Testing:**
- Tested against Mattermost, which is a large React open source app, and validated it added the displayName properties successfully
- Tested against another smaller React app I found on Github
