### PR TITLE
Add try-catch around displayName property update for non-extensible objects

### DIFF
--- a/index.js
+++ b/index.js
@@ -154,7 +154,7 @@ function addDisplayName(parser, node) {
     return // Assume lowercase names are helper functions and not Component classes 
   }
 
-  const dep = new ModuleAppenderDependency(`;${componentName}.displayName = "${componentName}";`, node.range)
+  const dep = new ModuleAppenderDependency(`;try{${componentName}.displayName="${componentName}";}catch{}`, node.range)
   dep.loc = node.loc
   parser.state.current.addDependency(dep)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-react-component-name",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Makes React component names public on minified bundles",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
We're seeing one instance where React component objects are being marked
as either frozen/sealed/non-extensible, and so the propertyName update is
failing due to the error: "Cannot add property displayName, object is not extensible".