### PR TITLE
Detect memoized React components

### DIFF
--- a/examples/memo/src/App.js
+++ b/examples/memo/src/App.js
@@ -1,0 +1,18 @@
+import React from "react"
+import { HashRouter } from "react-router-dom"
+
+import Button from "./Button"
+import MemoizedButton from "./MemoizedButton"
+import MemoizedButton2 from "./MemoizedButton2"
+
+export default function App() {
+  return (
+    <HashRouter>
+      <React.Fragment>
+        <Button></Button>
+        <MemoizedButton></MemoizedButton>
+        <MemoizedButton2></MemoizedButton2>
+      </React.Fragment>
+    </HashRouter>
+  )
+}

--- a/examples/memo/src/Button.js
+++ b/examples/memo/src/Button.js
@@ -1,0 +1,59 @@
+/* eslint-disable react/button-has-type */
+
+import React from 'react';
+import pt from 'prop-types';
+
+const noop = () => {};
+
+const Button = props => {
+    const {
+        disabled, type, variant, children, onClick
+    } = props;
+
+    if (variant === 'text') {
+        return <button
+            type='button'a
+            disabled={disabled}
+            onClick={onClick}
+        >
+            {children}
+        </button>;
+    }
+
+    return <button
+        type={type}
+        disabled={disabled}
+        onClick={onClick}
+    >
+        <span>
+            {children}
+        </span>
+    </button>;
+};
+
+Button.propTypes = {
+    block: pt.bool,
+    disabled: pt.bool,
+    loading: pt.bool,
+    type: pt.oneOf(['button', 'submit', 'reset']),
+    color: pt.oneOf(['primary', 'secondary', 'red', 'blue', 'green', 'yellow', 'white']),
+    variant: pt.oneOf(['default', 'contained', 'outlined', 'text']),
+    icon: pt.string,
+    iconPosition: pt.oneOf(['start', 'end']),
+    size: pt.oneOf(['default', 'large', 'small']),
+    onClick: pt.func
+};
+
+Button.defaultProps = {
+    block: false,
+    disabled: false,
+    loading: false,
+    type: 'button',
+    color: 'primary',
+    iconPosition: 'start',
+    variant: 'default',
+    size: 'default',
+    onClick: noop
+};
+
+export default Button;

--- a/examples/memo/src/MemoizedButton.js
+++ b/examples/memo/src/MemoizedButton.js
@@ -1,0 +1,6 @@
+import Button from "./Button";
+import React from 'react';
+
+const MemoizedButton = React.memo(Button);
+
+export default MemoizedButton

--- a/examples/memo/src/MemoizedButton2.js
+++ b/examples/memo/src/MemoizedButton2.js
@@ -1,0 +1,4 @@
+import Button from "./Button";
+import React from 'react';
+
+export const MemoizedButton2 = React.memo(() => { return Button });

--- a/examples/memo/src/index.js
+++ b/examples/memo/src/index.js
@@ -1,0 +1,11 @@
+import "core-js/es6/map";
+import "core-js/es6/set";
+import "raf/polyfill";
+
+import React from "react";
+import ReactDOM from "react-dom";
+
+import App from "./App";
+
+const root = document.getElementById("root");
+ReactDOM.render(<App />, root);

--- a/index.js
+++ b/index.js
@@ -73,7 +73,7 @@ class WebpackReactComponentNamePlugin {
                 node.callee.object &&
                 node.callee.object.name === 'React' &&
                 node.callee.property &&
-                node.callee.property.name === 'createElement'
+                ['createElement', 'memo'].includes(node.callee.property.name)
                 && ancestors
                 && ancestors.length > 1
               ) {
@@ -88,6 +88,8 @@ class WebpackReactComponentNamePlugin {
                     const variableDeclarator = ancestors[variableDeclaratorIdx]
                     addDisplayName(parser, variableDeclarator)
                   }
+                } else if (parentAncestor && parentAncestor.type === 'VariableDeclarator') {
+                  addDisplayName(parser, parentAncestor)
                 }
               }
             },

--- a/test/constants.js
+++ b/test/constants.js
@@ -119,6 +119,16 @@ exports.JSXELEMENT_WEBPACK_CONFIG = {
   module: MODULE_CONFIG
 }
 
+exports.MEMOIZED_WEBPACK_CONFIG = {
+  mode: PRODUCTION_MODE,
+  entry: path.join(__dirname, '../examples/memo/src/index.js'),
+  output: {
+    path: OUTPUT_DIR,
+    filename: 'memoizedbundle.js'
+  },
+  module: MODULE_CONFIG
+}
+
 exports.PARSE_TESTS_WEBPACK_CONFIG = {
   mode: PRODUCTION_MODE,
   entry: path.join(__dirname, '../examples/parsetests/src/index.js'),

--- a/test/plugin.spec.js
+++ b/test/plugin.spec.js
@@ -156,4 +156,20 @@ describe('WebpackReactComponentNamePlugin', () => {
     expect(minifiedSource).toContain('.displayName="App"')
     expect(numDisplayNameProperties).toEqual(11)
   })
+
+  it('detects memoized React components', async () => {
+    const result = await utils.testWebpackPlugin(_.merge(constants.MEMOIZED_WEBPACK_CONFIG, {
+      plugins: [new WebpackReactComponentNamePlugin()],
+    }))
+
+    const minifiedSource = result.compilation.assets[constants.MEMOIZED_WEBPACK_CONFIG.output.filename]._value
+
+    const numDisplayNameProperties = (minifiedSource.match(DISPLAY_NAME_REGEX) || []).length
+
+    expect(minifiedSource).toContain('.displayName="App"')
+    expect(minifiedSource).toContain('.displayName="Button"')
+    expect(minifiedSource).toContain('.displayName="MemoizedButton"')
+    expect(minifiedSource).toContain('.displayName="MemoizedButton2"')
+    expect(numDisplayNameProperties).toEqual(6)
+  })
 })


### PR DESCRIPTION
React components can be memoized via React.memo(). We now detect two variants of React.memo and set the displayName in these cases.