### PR TITLE
Add support for another variant of PureComponent

### DIFF
--- a/examples/purecomponent/src/App.js
+++ b/examples/purecomponent/src/App.js
@@ -2,12 +2,14 @@ import React from "react"
 import { HashRouter } from "react-router-dom"
 
 import UIButton from "./UIButton"
+import PureVariantOne from "./PureVariantOne"
 
 export default function App() {
   return (
     <HashRouter>
       <React.Fragment>
         <UIButton></UIButton>
+        <PureVariantOne></PureVariantOne>
       </React.Fragment>
     </HashRouter>
   )

--- a/examples/purecomponent/src/PureVariantOne.js
+++ b/examples/purecomponent/src/PureVariantOne.js
@@ -1,0 +1,19 @@
+import React, { PureComponent } from 'react';
+import classNames from 'classnames';
+
+export default class PureVariantOne extends PureComponent {
+    render() {
+        const {
+            foo
+        } = this.props;
+        return (
+            <p className={classNames(foo)}>
+                foo
+            </p>
+        );
+    }
+}
+
+PureVariantOne.defaultProps = {
+    type: 'exampleType',
+}

--- a/examples/purecomponent/src/UIButton.js
+++ b/examples/purecomponent/src/UIButton.js
@@ -1,4 +1,4 @@
-import React, { PureComponent } from 'react';
+import React from 'react';
 
 class UIButton extends React.PureComponent {
     render() {

--- a/index.js
+++ b/index.js
@@ -133,12 +133,20 @@ class WebpackReactComponentNamePlugin {
                 node.id &&
                 node.id.type === 'Identifier' &&
                 node.superClass &&
-                node.superClass.object &&
-                node.superClass.object.type === 'Identifier' &&
-                node.superClass.object.name === 'React' &&
-                node.superClass.property &&
-                node.superClass.property.type === 'Identifier' &&
-                ['Component', 'PureComponent'].includes(node.superClass.property.name)
+                (
+                  (
+                    node.superClass.object &&
+                    node.superClass.object.type === 'Identifier' &&
+                    node.superClass.object.name === 'React' &&
+                    node.superClass.property &&
+                    node.superClass.property.type === 'Identifier' &&
+                    ['Component', 'PureComponent'].includes(node.superClass.property.name)
+                  ) ||
+                  (
+                    node.superClass.type === 'Identifier' &&
+                    ['Component', 'PureComponent'].includes(node.superClass.name)
+                  )
+                )
               ) {
                 addDisplayName(parser, node)
               }

--- a/test/plugin.spec.js
+++ b/test/plugin.spec.js
@@ -139,7 +139,8 @@ describe('WebpackReactComponentNamePlugin', () => {
 
       expect(minifiedSource).toContain('.displayName="App"')
       expect(minifiedSource).toContain('.displayName="UIButton"')
-      expect(numDisplayNameProperties).toEqual(4)
+      expect(minifiedSource).toContain('.displayName="PureVariantOne"')
+      expect(numDisplayNameProperties).toEqual(5)
     }))
   })
 


### PR DESCRIPTION
Supports detection of PureComponents imported via the following method:

```
export default class PureVariantOne extends PureComponent
```

This now works for all variants of Babel configs that we test against,
whereas previously it only worked for a subset of Babel configs.