### PR TITLE
Handle imported React functions

### DIFF
--- a/examples/forwardref/src/App.js
+++ b/examples/forwardref/src/App.js
@@ -2,12 +2,14 @@ import React from "react"
 import { HashRouter } from "react-router-dom"
 
 import Dialog from "./Dialog"
+import Dialog2 from "./Dialog2"
 
 export default function App() {
   return (
     <HashRouter>
       <React.Fragment>
         <Dialog></Dialog>
+        <Dialog2></Dialog2>
       </React.Fragment>
     </HashRouter>
   )

--- a/examples/forwardref/src/Dialog2.js
+++ b/examples/forwardref/src/Dialog2.js
@@ -1,0 +1,54 @@
+import { forwardRef } from 'react';
+
+const Dialog2 = forwardRef((props, ref) => {
+  const {
+    isOpen = false,
+    hideCloseButton = false,
+    onClose,
+    position = 'center',
+    children,
+    onExited,
+    duration,
+    backdropProps,
+    className,
+    paperProps = {},
+    ...rest
+  } = props;
+  const handleBackdropClick = React.useCallback(
+    (ev) => {
+      if (ev.target !== ev.currentTarget) {
+        return;
+      }
+
+      if (onClose) {
+        onClose(ev, 'backdropClick');
+      }
+    },
+    [onClose]
+  );
+
+  const handleKeyDown = React.useCallback((ev) => {
+    if (ev.key === 'Escape') {
+      ev.stopPropagation();
+    }
+  }, []);
+
+  return (
+    <div
+      role="document"
+      onClick={handleBackdropClick}
+      onKeyDown={handleKeyDown}
+      // onMouseDown={handleMouseDown}
+      tabIndex={0}
+      style={{
+        display: 'flex',
+        alignItems: position === 'top' ? 'start' : 'center',
+        justifyContent: 'center',
+        height: '100%',
+        outline: 'none',
+      }}
+    ></div>
+  );
+});
+
+export default Dialog2;

--- a/examples/memo/src/App.js
+++ b/examples/memo/src/App.js
@@ -4,6 +4,7 @@ import { HashRouter } from "react-router-dom"
 import Button from "./Button"
 import MemoizedButton from "./MemoizedButton"
 import MemoizedButton2 from "./MemoizedButton2"
+import MemoizedButton3 from "./MemoizedButton3"
 
 export default function App() {
   return (
@@ -12,6 +13,7 @@ export default function App() {
         <Button></Button>
         <MemoizedButton></MemoizedButton>
         <MemoizedButton2></MemoizedButton2>
+        <MemoizedButton3></MemoizedButton3>
       </React.Fragment>
     </HashRouter>
   )

--- a/examples/memo/src/MemoizedButton3.js
+++ b/examples/memo/src/MemoizedButton3.js
@@ -1,0 +1,4 @@
+import Button from "./Button";
+import { memo } from 'react';
+
+export const MemoizedButton3 = memo(() => { return Button });

--- a/index.js
+++ b/index.js
@@ -57,14 +57,21 @@ class WebpackReactComponentNamePlugin {
               }
             },
 
-            CallExpression(node, ancestors) {
+            CallExpression(node, state, ancestors) {
               // Matches: const Foo = React.forwardRef((props, ref) => { .. }
               if (
                 node &&
                 node.callee &&
-                node.callee.type == 'MemberExpression' &&
-                node.callee.object.name === 'React' &&
-                node.callee.property.name === 'forwardRef'
+                ((
+                  node.callee.type === 'MemberExpression' &&
+                  node.callee.object.name === 'React' &&
+                  node.callee.property.name === 'forwardRef'
+                ) ||
+                (
+                  state.forwardRefFunctionImported
+                  && node.callee.type === 'Identifier'
+                  && node.callee.name ==='forwardRef'
+                ))
               ) {
                 const variableDeclarator = ancestors.find(ancestor => ancestor.type === 'VariableDeclarator')
 
@@ -76,11 +83,18 @@ class WebpackReactComponentNamePlugin {
               else if (
                 node &&
                 node.callee &&
-                node.callee.type === 'MemberExpression' &&
-                node.callee.object &&
-                node.callee.object.name === 'React' &&
-                node.callee.property &&
-                ['createElement', 'memo'].includes(node.callee.property.name)
+                ((
+                  node.callee.type === 'MemberExpression' &&
+                  node.callee.object &&
+                  node.callee.object.name === 'React' &&
+                  node.callee.property &&
+                  ['createElement', 'memo'].includes(node.callee.property.name)
+                ) ||
+                (
+                  state.memoFunctionImported
+                  && node.callee.type === 'Identifier'
+                  && node.callee.name ==='memo'
+                ))
                 && ancestors
                 && ancestors.length > 1
               ) {
@@ -151,13 +165,27 @@ class WebpackReactComponentNamePlugin {
               ) {
                 addDisplayName(parser, node)
               }
+            },
+
+            ImportDeclaration(node, state) {
+              // Matches: import { memo, forwardRef } from 'react'
+              if (
+                  node
+                  && node.source
+                  && node.source.value === 'react'
+                  && node.specifiers
+                  && node.specifiers.length > 0
+              ) {
+                state.memoFunctionImported ||= node.specifiers.some(s => s.type === 'ImportSpecifier' && s.imported.name === 'memo' )
+                state.forwardRefFunctionImported ||= node.specifiers.some(s => s.type === 'ImportSpecifier' && s.imported.name === 'forwardRef' )
+              }
             }
           },
           {
             ...walk.base,
             // Add any objects that acorn-walk doesn't handle by default and thus would throw a ModuleParseError otherwise
             Import: () => {}
-          })
+          }, {})
         })
       })
     })

--- a/index.js
+++ b/index.js
@@ -176,8 +176,8 @@ class WebpackReactComponentNamePlugin {
                   && node.specifiers
                   && node.specifiers.length > 0
               ) {
-                state.memoFunctionImported ||= node.specifiers.some(s => s.type === 'ImportSpecifier' && s.imported.name === 'memo' )
-                state.forwardRefFunctionImported ||= node.specifiers.some(s => s.type === 'ImportSpecifier' && s.imported.name === 'forwardRef' )
+                state.memoFunctionImported = state.memoFunctionImported || node.specifiers.some(s => s.type === 'ImportSpecifier' && s.imported.name === 'memo' )
+                state.forwardRefFunctionImported = state.forwardRefFunctionImported || node.specifiers.some(s => s.type === 'ImportSpecifier' && s.imported.name === 'forwardRef' )
               }
             }
           },

--- a/test/plugin.spec.js
+++ b/test/plugin.spec.js
@@ -127,7 +127,8 @@ describe('WebpackReactComponentNamePlugin', () => {
 
       expect(minifiedSource).toContain('.displayName="App"')
       expect(minifiedSource).toContain('.displayName="Dialog"')
-      expect(numDisplayNameProperties).toEqual(3)
+      expect(minifiedSource).toContain('.displayName="Dialog2"')
+      expect(numDisplayNameProperties).toEqual(4)
     }
   })
 
@@ -186,7 +187,8 @@ describe('WebpackReactComponentNamePlugin', () => {
       expect(minifiedSource).toContain('.displayName="Button"')
       expect(minifiedSource).toContain('.displayName="MemoizedButton"')
       expect(minifiedSource).toContain('.displayName="MemoizedButton2"')
-      expect(numDisplayNameProperties).toEqual(5)
+      expect(minifiedSource).toContain('.displayName="MemoizedButton3"')
+      expect(numDisplayNameProperties).toEqual(6)
     }
   })
 


### PR DESCRIPTION
Our codebase uses `memo(...)` and `forwardRef(...)` directly without `React.`
I think it can be a pretty common use case ;)