### PR TITLE
Add OptionsParser class

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 const walk = require("acorn-walk")
 const ModuleAppenderDependency = require('./lib/module-appender')
-const PureExpressionDependency = require("webpack/lib/dependencies/PureExpressionDependency")
+const OptionsParser = require('./lib/options-parser')
 
 // Keep track of the nodes we update so we don't make duplicate updates
 const updatedNodes = new Set()
@@ -19,7 +19,7 @@ const VALID_FILE_SUFFIXES_REGEX = /\.(js|jsx|ts|tsx)$/
 // https://developer.mozilla.org/en-US/docs/Mozilla/Projects/SpiderMonkey/Parser_API
 class WebpackReactComponentNamePlugin {
   constructor(options) {
-    this.options = options ?? {}
+    this.options = new OptionsParser().parse(options)
   }
   apply(compiler) {
     compiler.hooks.compilation.tap(

--- a/lib/options-parser.js
+++ b/lib/options-parser.js
@@ -1,0 +1,21 @@
+/**
+ * Reads and validates the options passed to the Webpack plugin.
+ */
+class OptionsParser {
+  parse(options) {
+    const optionsWithDefaults = {
+      parseDependencies: options?.parseDependencies ?? false,
+    }
+
+    // Check if caller set any invalid options
+    for (const [key, value] of Object.entries(options ?? {})) {
+      if (!optionsWithDefaults.hasOwnProperty(key) && value != null) {
+        throw new Error(`Unsupported option ${key} with value ${value}`)
+      }
+    }
+
+    return optionsWithDefaults
+  }
+}
+
+module.exports = OptionsParser

--- a/test/options-parser.spec.js
+++ b/test/options-parser.spec.js
@@ -1,0 +1,19 @@
+const OptionsParser = require('../lib/options-parser')
+
+const optionsParser = new OptionsParser()
+
+describe('OptionsParser', () => {
+  it('sets default options if undefined', () => {
+    expect(optionsParser.parse(undefined)).toEqual({ parseDependencies: false })
+  })
+
+  it('sets options passed to parser', () => {
+    expect(optionsParser.parse({ parseDependencies: true })).toEqual({ parseDependencies: true })
+  })
+
+  it('throws error if unsupported option is passed', () => {
+    expect(function() {
+      optionsParser.parse({ foo: 'bar' })
+    }).toThrow(new Error('Unsupported option foo with value bar'))
+  })
+})


### PR DESCRIPTION
Adds a simple class for parsing options to the plugin. This handles
default values and ensures other code can depend on the options
object to not have missing values.