### PR TITLE
Add support for file-based inclusion / exclusion rules (#27) 

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,9 @@ npm install webpack-react-component-name -save-dev
 
 ```json
 {
-  "parseDependencies": false
+  "parseDependencies": false,
+  "include": [],
+  "exclude": []
 }
 ```
 
@@ -51,6 +53,22 @@ Default: `false`
 
 If set true, the plugin will name the components exported from node_modules.
 
+
+### include 
+Type: `(string | RegExp | (path: string) => boolean)[]` Default: `[]`
+
+If the path matches any of the elements in this array, it will be included if it isn't explicitly excluded.
+
+If the item is a `string`, it will use standard glob syntax. If the item is a Regular Expression, the path will be tested against it. If the item is a function, the path will be passed into it for testing. 
+
+### exclude 
+Type: `(string | RegExp | (path: string) => boolean)[]` Default: `[]`
+
+If the path matches any of the elements in this array, it will be excluded.
+
+If the item is a `string`, it will use standard glob syntax. If the item is a Regular Expression, the path will be tested against it. If the item is a function, the path will be passed into it for testing. 
+
+A truthy result will be excluded. 
 ## Troubleshooting
 
 As you probably know, there is more than one way to define a React component.  This

--- a/index.js
+++ b/index.js
@@ -37,8 +37,9 @@ class WebpackReactComponentNamePlugin {
         parser.hooks.program.tap("WebpackReactComponentNamePlugin", ast => {
           // Ignore dependency files
           if (parser.state.current.resource == null 
-            || (!this.options.parseDependencies && parser.state.current.resource.indexOf("node_modules") !== -1) 
-            || !VALID_FILE_SUFFIXES_REGEX.test(parser.state.current.resource.toLowerCase())) {
+            || !VALID_FILE_SUFFIXES_REGEX.test(parser.state.current.resource)
+            || (this.options.include.length && this.options.include.every(match => !match(parser.state.current.resource)))
+            || (this.options.exclude.length && this.options.exclude.some(match => match(parser.state.current.resource)))) {
             return
           }
 

--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ class WebpackReactComponentNamePlugin {
         parser.hooks.program.tap("WebpackReactComponentNamePlugin", ast => {
           // Ignore dependency files
           if (parser.state.current.resource == null 
-            || !VALID_FILE_SUFFIXES_REGEX.test(parser.state.current.resource)
+            || !VALID_FILE_SUFFIXES_REGEX.test(parser.state.current.resource.toLowerCase())
             || (this.options.include.length && this.options.include.every(match => !match(parser.state.current.resource)))
             || (this.options.exclude.length && this.options.exclude.some(match => match(parser.state.current.resource)))) {
             return

--- a/lib/options-parser.js
+++ b/lib/options-parser.js
@@ -1,3 +1,19 @@
+const { Minimatch } = require("minimatch")
+
+/**
+ * Resolves the matchers in an array.
+ */
+function resolveMatchers(match)  {
+  if (typeof match === 'string') {
+    const minimatch = new Minimatch(match)
+    return (path) => minimatch.match(path)
+  }
+  if (match instanceof RegExp) return (path) => match.test(path)
+  if (typeof match === 'function') return match
+  throw new Error(`Unrecognized parameter: ${match}; expected string, RegExp, or function.`)
+}
+
+
 /**
  * Reads and validates the options passed to the Webpack plugin.
  */
@@ -5,6 +21,8 @@ class OptionsParser {
   parse(options) {
     const optionsWithDefaults = {
       parseDependencies: options?.parseDependencies ?? false,
+      exclude: options?.exclude ?? [], 
+      include: options?.include ?? []
     }
 
     // Check if caller set any invalid options
@@ -14,7 +32,15 @@ class OptionsParser {
       }
     }
 
+    if (!optionsWithDefaults.parseDependencies) optionsWithDefaults.exclude.push(this.ignoreNodeModules)
+    optionsWithDefaults.include = optionsWithDefaults.include.map(resolveMatchers)
+    optionsWithDefaults.exclude = optionsWithDefaults.exclude.map(resolveMatchers)
+
     return optionsWithDefaults
+  }
+
+  ignoreNodeModules(path) {
+    return path.indexOf("node_modules") !== -1
   }
 }
 

--- a/lib/options-parser.js
+++ b/lib/options-parser.js
@@ -1,7 +1,8 @@
 const { Minimatch } = require("minimatch")
 
 /**
- * Resolves the matchers in an array.
+ * Resolves the matchers into a function, to provide a 
+ * consistent interface regardless of the matcher type.
  */
 function resolveMatchers(match)  {
   if (typeof match === 'string') {

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "webpack": "5.x"
   },
   "dependencies": {
-    "acorn-walk": "7.2.0"
+    "acorn-walk": "7.2.0",
+    "minimatch": "^5.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -60,6 +60,6 @@
   },
   "dependencies": {
     "acorn-walk": "7.2.0",
-    "minimatch": "^5.1.0"
+    "minimatch": "5.1.0"
   }
 }

--- a/test/constants.js
+++ b/test/constants.js
@@ -1,6 +1,7 @@
 const path = require('path')
 
 const OUTPUT_DIR = path.resolve(__dirname, '../dist/examples')
+exports.OUTPUT_DIR = OUTPUT_DIR
 
 const PRODUCTION_MODE = 'production'
 const BABEL_CONFIG_WITH_PRESENT_ENV = {

--- a/test/options-parser.spec.js
+++ b/test/options-parser.spec.js
@@ -4,11 +4,19 @@ const optionsParser = new OptionsParser()
 
 describe('OptionsParser', () => {
   it('sets default options if undefined', () => {
-    expect(optionsParser.parse(undefined)).toEqual({ parseDependencies: false })
+    expect(optionsParser.parse(undefined)).toEqual({ 
+      parseDependencies: false, 
+      include: [], 
+      exclude: [optionsParser.ignoreNodeModules] 
+    })
   })
 
   it('sets options passed to parser', () => {
-    expect(optionsParser.parse({ parseDependencies: true })).toEqual({ parseDependencies: true })
+    expect(optionsParser.parse({ parseDependencies: true })).toEqual({ 
+      parseDependencies: true, 
+      include: [], 
+      exclude: [] 
+    })
   })
 
   it('throws error if unsupported option is passed', () => {

--- a/test/plugin.spec.js
+++ b/test/plugin.spec.js
@@ -208,6 +208,30 @@ describe('WebpackReactComponentNamePlugin', () => {
     expect(minifiedSource).toContain('.displayName="TodoItem"')
     expect(numDisplayNameProperties).toEqual(3)
   })
+
+  it('handles include / exclude options', async () => {
+    // Note that this test only works with one flavor of Babel loader, so we're only testing one here
+    await utils.testWebpackPlugin(_.merge(_.cloneDeep(constants.TODOMVC_WEBPACK_CONFIG), {
+      plugins: [new WebpackReactComponentNamePlugin({
+        // Regex expressions work, also strings use minimatch to support glob patterns,
+        // and functions.
+        include: ['**/containers/*.js', /App\.js/], // If any of these pass, it will be included if it isn't excluded.
+        exclude: [i => i.includes('Item')] 
+      })],
+      output: {
+        path: constants.OUTPUT_DIR,
+        filename: 'limitedtodomvc.js'
+      },
+      module: constants.DEFAULT_BABEL_CONFIG,
+    }))
+
+    const minifiedSource = readSourceFile('limitedtodomvc.js')
+    const numDisplayNameProperties = (minifiedSource.match(DISPLAY_NAME_REGEX) || []).length
+
+    expect(minifiedSource).toContain('.displayName="App"')
+    expect(minifiedSource).toContain('.displayName="TodoList"')
+    expect(numDisplayNameProperties).toEqual(4) // Components plus Provider, Consumer, and Router
+  })
 })
 
 /**
@@ -223,5 +247,5 @@ function generateWebpackConfigs(baseWebpackConfig) {
 }
 
 function readSourceFile(filename) {
-  return fs.readFileSync('dist/examples/' + filename).toString()
+  return fs.readFileSync(constants.OUTPUT_DIR + '/' + filename).toString()
 }


### PR DESCRIPTION
Hi, 

I've tried my hand at implementing the file-based inclusion & exclusion rules.

Options will now accept arrays,

```
include: (RegExp | string | (path: string) => boolean)[],
exclude: (RegExp | string | (path: string) => boolean)[]
```

This setup should allow plugin users a great deal of control over how they can filter which files are consumed by the plugin.

If a string is passed in, it will be parsed by Minimatch to support standard glob syntax.
If a function is passed in, it will expect a path parameter to be passed in, and it should return `true` if it passes the rule.
If a RegExp is passed in, it will test any paths with that RegExp. 

While with the function based approach, it's possible to get away with just an `include` field, having `exclude` present will greatly simplify certain types of setups that would be semi-cumbersome just glob syntax.

For example, I could configure:
```js
new WebpackReactComponentName({
    include: ["**/*Wizard/**"],
    exclude: [/alertsWizard/] 
})
```

To import a handful of wizard components & exclude a specific one. 

Hopefully the code appears clean & maintainable! 
